### PR TITLE
Add interactive PDF web editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,155 @@
+import os
+import shutil
+import tempfile
+import zipfile
+
+from flask import Flask, render_template, request, send_file, abort
+
+import main as pdf
+
+app = Flask(__name__)
+app.secret_key = 'dev'
+
+EDIT_FILES = {}
+
+
+def save_upload(file_storage):
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.pdf')
+    file_storage.save(tmp.name)
+    return tmp
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/edit', methods=['GET', 'POST'])
+def edit():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file:
+            abort(400, 'No file uploaded')
+        upload = save_upload(file)
+        fid = os.path.basename(upload.name)
+        EDIT_FILES[fid] = upload.name
+        return render_template('editor.html', file_id=fid)
+    return render_template('upload.html')
+
+
+@app.route('/get_pdf/<fid>')
+def get_pdf(fid):
+    path = EDIT_FILES.get(fid)
+    if not path or not os.path.exists(path):
+        abort(404)
+    return send_file(path)
+
+
+@app.route('/apply_edits/<fid>', methods=['POST'])
+def apply_edits(fid):
+    path = EDIT_FILES.get(fid)
+    if not path or not os.path.exists(path):
+        abort(404)
+    edits = request.get_json().get('edits', [])
+    output = tempfile.NamedTemporaryFile(delete=False, suffix='.pdf')
+    pdf.apply_edits(path, output.name, edits)
+    return send_file(output.name, as_attachment=True, download_name='edited.pdf')
+
+
+@app.route('/merge', methods=['POST'])
+def merge():
+    files = request.files.getlist('files')
+    if not files:
+        abort(400, 'No files provided')
+    uploads = [save_upload(f) for f in files]
+    output = tempfile.NamedTemporaryFile(delete=False, suffix='.pdf')
+    pdf.merge_pdfs(output.name, [u.name for u in uploads])
+    for u in uploads:
+        os.unlink(u.name)
+    return send_file(output.name, as_attachment=True, download_name='merged.pdf')
+
+
+@app.route('/split', methods=['POST'])
+def split():
+    file = request.files.get('file')
+    if not file:
+        abort(400, 'No file provided')
+    start = request.form.get('start')
+    end = request.form.get('end')
+    start = int(start) if start else None
+    end = int(end) if end else None
+
+    upload = save_upload(file)
+    out_dir = tempfile.mkdtemp()
+    prefix = os.path.join(out_dir, 'split')
+    pdf.split_pdf(upload.name, prefix, start, end)
+
+    zip_tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.zip')
+    with zipfile.ZipFile(zip_tmp.name, 'w') as zf:
+        for fname in sorted(os.listdir(out_dir)):
+            zf.write(os.path.join(out_dir, fname), fname)
+    shutil.rmtree(out_dir)
+    os.unlink(upload.name)
+    return send_file(zip_tmp.name, as_attachment=True, download_name='split.zip')
+
+
+@app.route('/rotate', methods=['POST'])
+def rotate():
+    file = request.files.get('file')
+    if not file:
+        abort(400, 'No file provided')
+    angle = int(request.form.get('angle', 90))
+    upload = save_upload(file)
+    output = tempfile.NamedTemporaryFile(delete=False, suffix='.pdf')
+    pdf.rotate_pages(upload.name, output.name, angle)
+    os.unlink(upload.name)
+    return send_file(output.name, as_attachment=True, download_name='rotated.pdf')
+
+
+@app.route('/remove', methods=['POST'])
+def remove():
+    file = request.files.get('file')
+    if not file:
+        abort(400, 'No file provided')
+    pages = request.form.get('pages', '')
+    pages = [int(p.strip()) for p in pages.split(',') if p.strip().isdigit()]
+    upload = save_upload(file)
+    output = tempfile.NamedTemporaryFile(delete=False, suffix='.pdf')
+    pdf.remove_pages(upload.name, output.name, pages)
+    os.unlink(upload.name)
+    return send_file(output.name, as_attachment=True, download_name='removed.pdf')
+
+
+@app.route('/add_text', methods=['POST'])
+def add_text():
+    file = request.files.get('file')
+    if not file:
+        abort(400, 'No file provided')
+    text = request.form.get('text', '')
+    x = float(request.form.get('x', 100))
+    y = float(request.form.get('y', 750))
+    page_num = int(request.form.get('page', 0))
+    upload = save_upload(file)
+    output = tempfile.NamedTemporaryFile(delete=False, suffix='.pdf')
+    pdf.add_text(upload.name, output.name, text, x, y, page_num)
+    os.unlink(upload.name)
+    return send_file(output.name, as_attachment=True, download_name='text.pdf')
+
+
+@app.route('/watermark', methods=['POST'])
+def watermark():
+    file = request.files.get('file')
+    watermark_file = request.files.get('watermark')
+    if not file or not watermark_file:
+        abort(400, 'File or watermark missing')
+    pdf_file = save_upload(file)
+    wm_file = save_upload(watermark_file)
+    output = tempfile.NamedTemporaryFile(delete=False, suffix='.pdf')
+    pdf.apply_watermark(pdf_file.name, wm_file.name, output.name)
+    os.unlink(pdf_file.name)
+    os.unlink(wm_file.name)
+    return send_file(output.name, as_attachment=True, download_name='watermarked.pdf')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/main.py
+++ b/main.py
@@ -1,2 +1,165 @@
+import argparse
+from PyPDF2 import PdfReader, PdfWriter, PdfMerger
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
+from io import BytesIO
+
+
+def merge_pdfs(output_path, inputs):
+    merger = PdfMerger()
+    for pdf in inputs:
+        merger.append(pdf)
+    with open(output_path, 'wb') as f:
+        merger.write(f)
+
+
+def split_pdf(input_path, output_prefix, start=None, end=None):
+    reader = PdfReader(input_path)
+    pages = reader.pages[start:end]
+    for idx, page in enumerate(pages, start=start or 0):
+        writer = PdfWriter()
+        writer.add_page(page)
+        out_path = f"{output_prefix}_page_{idx + 1}.pdf"
+        with open(out_path, 'wb') as f:
+            writer.write(f)
+
+
+def rotate_pages(input_path, output_path, angle):
+    reader = PdfReader(input_path)
+    writer = PdfWriter()
+    for page in reader.pages:
+        page.rotate(angle)
+        writer.add_page(page)
+    with open(output_path, 'wb') as f:
+        writer.write(f)
+
+
+def remove_pages(input_path, output_path, pages):
+    reader = PdfReader(input_path)
+    writer = PdfWriter()
+    for idx, page in enumerate(reader.pages):
+        if idx not in pages:
+            writer.add_page(page)
+    with open(output_path, 'wb') as f:
+        writer.write(f)
+
+
+def add_text(input_path, output_path, text, x, y, page_num):
+    reader = PdfReader(input_path)
+    writer = PdfWriter()
+    packet = BytesIO()
+    can = canvas.Canvas(packet, pagesize=letter)
+    can.drawString(x, y, text)
+    can.save()
+    packet.seek(0)
+    overlay_pdf = PdfReader(packet)
+    overlay_page = overlay_pdf.pages[0]
+
+    for idx, page in enumerate(reader.pages):
+        if idx == page_num:
+            page.merge_page(overlay_page)
+        writer.add_page(page)
+    with open(output_path, 'wb') as f:
+        writer.write(f)
+
+
+def apply_edits(input_path, output_path, edits):
+    """Apply multiple text edits described by a list of dictionaries.
+
+    Each dictionary must contain ``page`` (0-index), ``text``, ``x`` and ``y``
+    coordinates in PDF points.
+    """
+    reader = PdfReader(input_path)
+    writer = PdfWriter()
+
+    edit_map = {}
+    for e in edits:
+        page = int(e.get('page', 0))
+        edit_map.setdefault(page, []).append(e)
+
+    for idx, page in enumerate(reader.pages):
+        if idx in edit_map:
+            packet = BytesIO()
+            can = canvas.Canvas(
+                packet,
+                pagesize=(float(page.mediabox.width), float(page.mediabox.height)),
+            )
+            for e in edit_map[idx]:
+                can.drawString(float(e.get('x', 0)), float(e.get('y', 0)), e.get('text', ''))
+            can.save()
+            packet.seek(0)
+            overlay = PdfReader(packet).pages[0]
+            page.merge_page(overlay)
+        writer.add_page(page)
+
+    with open(output_path, 'wb') as f:
+        writer.write(f)
+
+
+def apply_watermark(input_path, watermark_path, output_path):
+    watermark = PdfReader(watermark_path).pages[0]
+    reader = PdfReader(input_path)
+    writer = PdfWriter()
+    for page in reader.pages:
+        page.merge_page(watermark)
+        writer.add_page(page)
+    with open(output_path, 'wb') as f:
+        writer.write(f)
+
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Advanced PDF editor")
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    merge_cmd = subparsers.add_parser('merge', help='Merge PDF files')
+    merge_cmd.add_argument('output', help='Output PDF file')
+    merge_cmd.add_argument('inputs', nargs='+', help='Input PDF files')
+
+    split_cmd = subparsers.add_parser('split', help='Split PDF file')
+    split_cmd.add_argument('input', help='Input PDF file')
+    split_cmd.add_argument('output_prefix', help='Prefix for output files')
+    split_cmd.add_argument('--start', type=int, default=None, help='Start page (0-index)')
+    split_cmd.add_argument('--end', type=int, default=None, help='End page (exclusive, 0-index)')
+
+    rotate_cmd = subparsers.add_parser('rotate', help='Rotate all pages')
+    rotate_cmd.add_argument('input', help='Input PDF file')
+    rotate_cmd.add_argument('output', help='Output PDF file')
+    rotate_cmd.add_argument('--angle', type=int, default=90, help='Rotation angle')
+
+    remove_cmd = subparsers.add_parser('remove', help='Remove pages by index')
+    remove_cmd.add_argument('input', help='Input PDF file')
+    remove_cmd.add_argument('output', help='Output PDF file')
+    remove_cmd.add_argument('pages', nargs='+', type=int, help='Page indices to remove (0-index)')
+
+    text_cmd = subparsers.add_parser('add-text', help='Add text to a page')
+    text_cmd.add_argument('input', help='Input PDF file')
+    text_cmd.add_argument('output', help='Output PDF file')
+    text_cmd.add_argument('text', help='Text to add')
+    text_cmd.add_argument('--x', type=float, default=100, help='X coordinate')
+    text_cmd.add_argument('--y', type=float, default=750, help='Y coordinate')
+    text_cmd.add_argument('--page', type=int, default=0, help='Page number (0-index)')
+
+    wm_cmd = subparsers.add_parser('watermark', help='Apply watermark PDF')
+    wm_cmd.add_argument('input', help='Input PDF file')
+    wm_cmd.add_argument('watermark', help='Watermark PDF file (single page)')
+    wm_cmd.add_argument('output', help='Output PDF file')
+
+    args = parser.parse_args()
+
+    if args.command == 'merge':
+        merge_pdfs(args.output, args.inputs)
+    elif args.command == 'split':
+        split_pdf(args.input, args.output_prefix, args.start, args.end)
+    elif args.command == 'rotate':
+        rotate_pages(args.input, args.output, args.angle)
+    elif args.command == 'remove':
+        remove_pages(args.input, args.output, args.pages)
+    elif args.command == 'add-text':
+        add_text(args.input, args.output, args.text, args.x, args.y, args.page)
+    elif args.command == 'watermark':
+        apply_watermark(args.input, args.watermark, args.output)
+
+
 if __name__ == "__main__":
-    pass
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyPDF2
+reportlab
+Flask

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>PDF Editor</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body class="bg-light">
+    <div class="container py-4">
+      <h1 class="text-center mb-4">PDF Editor</h1>
+      {% block content %}{% endblock %}
+    </div>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -1,0 +1,73 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="mb-3">
+  <input id="text" class="form-control" placeholder="Text to insert">
+</div>
+<div id="viewer"></div>
+<div class="mt-3">
+  <button class="btn btn-success" onclick="save()">Save</button>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+<script>
+const edits = [];
+const url = '/get_pdf/{{ file_id }}';
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
+
+function render() {
+  pdfjsLib.getDocument(url).promise.then(pdf => {
+    const viewer = document.getElementById('viewer');
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      pdf.getPage(pageNum).then(page => {
+        const viewport = page.getViewport({scale:1.5});
+        const div = document.createElement('div');
+        div.id = 'page-' + (pageNum-1);
+        div.className = 'position-relative mb-2';
+        const canvas = document.createElement('canvas');
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        div.appendChild(canvas);
+        viewer.appendChild(div);
+        page.render({canvasContext: canvas.getContext('2d'), viewport: viewport});
+        canvas.addEventListener('click', e => {
+          const rect = canvas.getBoundingClientRect();
+          const x = e.clientX - rect.left;
+          const y = canvas.height - (e.clientY - rect.top);
+          const text = document.getElementById('text').value;
+          if (!text) return;
+          addMark(div, text, x, y);
+          edits.push({page: pageNum-1, x: x, y: y, text: text});
+        });
+      });
+    }
+  });
+}
+
+function addMark(container, text, x, y) {
+  const span = document.createElement('span');
+  span.textContent = text;
+  span.style.position = 'absolute';
+  span.style.left = x + 'px';
+  span.style.bottom = y + 'px';
+  span.style.color = 'red';
+  container.appendChild(span);
+}
+
+function save() {
+  fetch('/apply_edits/{{ file_id }}', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({edits: edits})
+  }).then(r => r.blob()).then(b => {
+    const url = URL.createObjectURL(b);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'edited.pdf'; a.click();
+    URL.revokeObjectURL(url);
+  });
+}
+
+render();
+</script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,88 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header">Merge PDFs</div>
+      <div class="card-body">
+        <form action="/merge" method="post" enctype="multipart/form-data">
+          <input class="form-control mb-3" type="file" name="files" multiple required>
+          <button class="btn btn-primary" type="submit">Merge</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header">Split PDF</div>
+      <div class="card-body">
+        <form action="/split" method="post" enctype="multipart/form-data">
+          <input class="form-control mb-3" type="file" name="file" required>
+          <input class="form-control mb-3" type="number" name="start" placeholder="Start page" min="0">
+          <input class="form-control mb-3" type="number" name="end" placeholder="End page">
+          <button class="btn btn-primary" type="submit">Split</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header">Rotate Pages</div>
+      <div class="card-body">
+        <form action="/rotate" method="post" enctype="multipart/form-data">
+          <input class="form-control mb-3" type="file" name="file" required>
+          <input class="form-control mb-3" type="number" name="angle" value="90" required>
+          <button class="btn btn-primary" type="submit">Rotate</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header">Remove Pages</div>
+      <div class="card-body">
+        <form action="/remove" method="post" enctype="multipart/form-data">
+          <input class="form-control mb-3" type="file" name="file" required>
+          <input class="form-control mb-3" type="text" name="pages" placeholder="Pages (comma-separated)">
+          <button class="btn btn-primary" type="submit">Remove</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header">Add Text</div>
+      <div class="card-body">
+        <form action="/add_text" method="post" enctype="multipart/form-data">
+          <input class="form-control mb-3" type="file" name="file" required>
+          <input class="form-control mb-3" type="text" name="text" placeholder="Text" required>
+          <input class="form-control mb-3" type="number" name="x" value="100" step="any">
+          <input class="form-control mb-3" type="number" name="y" value="750" step="any">
+          <input class="form-control mb-3" type="number" name="page" value="0">
+          <button class="btn btn-primary" type="submit">Add</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header">Apply Watermark</div>
+      <div class="card-body">
+        <form action="/watermark" method="post" enctype="multipart/form-data">
+          <input class="form-control mb-3" type="file" name="file" required>
+          <input class="form-control mb-3" type="file" name="watermark" required>
+          <button class="btn btn-primary" type="submit">Apply</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header">Advanced Editor</div>
+      <div class="card-body d-flex align-items-center">
+        <a class="btn btn-success w-100" href="/edit">Launch Editor</a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<form action="/edit" method="post" enctype="multipart/form-data" class="mb-3">
+  <input class="form-control mb-3" type="file" name="file" required>
+  <button class="btn btn-primary" type="submit">Upload</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- expose new `/edit` workflow with an interactive PDF editor using pdf.js
- implement server-side `apply_edits` to overlay multiple texts
- include upload and editor templates
- allow custom scripts block in base template

## Testing
- `python -m py_compile main.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_685a66559d24832e9ce44b524f0cc8fe